### PR TITLE
Generalize plotting

### DIFF
--- a/braketlab/braketlab.py
+++ b/braketlab/braketlab.py
@@ -158,7 +158,7 @@ def show(*p, t=None):
     show(a, b)
     """
     mpfig = False
-    mv = 1
+    mvx = 1
 
     
     for i in list(p):
@@ -176,7 +176,7 @@ def show(*p, t=None):
             plt.plot([vec_R2[0]], [vec_R2[1]], "o", color = (0,0,0))
             plt.text(vec_R2[0]+.1, vec_R2[1], "%s" % i.__name__)
 
-            mv = max( mv, max(vec_R2[1], vec_R2[0]) ) 
+            mvx = max( mvx, max(vec_R2[1], vec_R2[0]) ) 
             
                 
                 
@@ -186,8 +186,9 @@ def show(*p, t=None):
             vars = list(spe.free_symbols)
             nd = len(vars)
             Nx = 200
-            x = np.linspace(-8,8,200)
-            mv = 8
+            mvx = 8
+            x = np.linspace(-mvx, mvx, Nx)
+            
             if nd == 1:
                 if not mpfig:
                     mpfig = True
@@ -255,8 +256,13 @@ def show(*p, t=None):
 
     if mpfig:
         plt.grid()
-        plt.xlim(-mv-1,mv+1)
-        plt.ylim(-mv-1,mv+1)
+        mvx = max(x)
+        if nd == 1:
+            mvy = max(i(x))
+        if nd == 2:
+            mvy = mvx
+        plt.xlim(-1.1*mvx, 1.1*mvx)
+        plt.ylim(-1.1*mvy, 1.1*mvy)
         plt.legend()
         plt.show()
         
@@ -277,8 +283,9 @@ def show_old(*p, t=None):
     """
     plt.figure(figsize=(6,6))
     try:
+        mvx = 8
         Nx = 200
-        x = np.linspace(-8,8,200)
+        x = np.linspace(-mvx, mvx, Nx)
         Z = np.zeros((Nx, Nx, 3), dtype = float)
         colors = np.random.uniform(0,1,(len(list(p)), 3))
         
@@ -293,21 +300,21 @@ def show_old(*p, t=None):
             
 
     except:
-        mv = 1
+        mvx = 1
         #plt.figure(figsize = (6,6))
         for i in list(p):
             vec_R2 = i.coefficients[0]*i.basis[0] + i.coefficients[1]*i.basis[1]
             plt.plot([0, vec_R2[0]], [0, vec_R2[1]], "-")
             
             plt.plot([vec_R2[0]], [vec_R2[1]], "o", color = (0,0,0))
-            plt.text(vec_R2[0]+.1, vec_R2[1], "%s" % i.__name__)
+            plt.text(vec_R2[0]+.2, vec_R2[1], "%s" % i.__name__)
 
-            mv = max( mv, max(vec_R2[1], vec_R2[0]) ) 
+            mvx = max( mvx, max(vec_R2[1], vec_R2[0]) ) 
             
             
         plt.grid()
-        plt.xlim(-mv-1,mv+1)
-        plt.ylim(-mv-1,mv+1)
+        plt.xlim(-1.1*mvx, 1.1*mvx)
+        plt.ylim(-1.1*mvx, 1.1*mvx)
     plt.show()
 
     

--- a/testing/generalize_plotting_tests.py
+++ b/testing/generalize_plotting_tests.py
@@ -1,0 +1,25 @@
+import braketlab as bk 
+import sympy as sp
+import numpy as np 
+
+x, y = bk.get_default_variables(1,2)
+x = sp.symbols('x')
+y = sp.symbols('y')
+
+a = bk.ket( [ 2,4], name = "a")
+b = bk.ket( [-2,3], name = "b")
+
+bk.show_old(a, b, a-b, a+b)
+
+N = 50
+sigma = 20
+k = 5
+
+c = bk.ket((N*sp.exp(-1/2*sigma*x**2)), name = "c")
+bk.show(c)
+d = bk.ket( x*sp.exp(-.2*(x**2 + y**2) ), name = "d")
+bk.show(d)
+
+e = bk.ket((2*N*sp.exp(-1/2*sigma*x**2)), name = "e")
+bk.show(c, e)
+


### PR DESCRIPTION
Made some changes to generalize the plotting using the show() and show_old() functions. In some cases, y- and x-axes must be of different lengths, so the mv variable has been changed to mvx or mvy, as appropriate, throughout the code. Vectors can still only be plotted with show_old(). Some testing is done using testing/generalize_plotting_tests.py, and it seems the plots in the tutorial are reproduced.