### PR TITLE
Dependencies and SyntaxWarnings

### DIFF
--- a/braketlab/animate.py
+++ b/braketlab/animate.py
@@ -59,10 +59,10 @@ class animated_system():
         
         c1,c2,c3 = colorscheme().getcol(np.random.uniform(0,1,3))
         
-        self.bubbles = self.ax.plot(x, p, "-", color = (0,0,0), markersize = 1, label = "$\\vert \Psi \\vert^2$")[0]
+        self.bubbles = self.ax.plot(x, p, "-", color = (0,0,0), markersize = 1, label = r"$\\vert \Psi \\vert^2$")[0]
         
-        self.wf_imag = self.ax.plot(x, w.imag, "-", color = c1**.5, markersize = 1, label = "Im($\Psi$)")[0]
-        self.wf_real = self.ax.plot(x, w.real, "-", color = c2**.5, markersize = 1, label = "Re($\Psi$)")[0]
+        self.wf_imag = self.ax.plot(x, w.imag, "-", color = c1**.5, markersize = 1, label = r"Im($\Psi$)")[0]
+        self.wf_real = self.ax.plot(x, w.real, "-", color = c2**.5, markersize = 1, label = r"Re($\Psi$)")[0]
         
         self.ax.legend()
         

--- a/braketlab/core.py
+++ b/braketlab/core.py
@@ -363,7 +363,7 @@ def construct_basis(p):
 
 
 class basisfunction:
-    """
+    r"""
     # A general class for a basis function in $\mathbb{R}^n$
 
     ## Keyword arguments:
@@ -400,9 +400,9 @@ class basisfunction:
     position = None
     normalization = 1
     domain = None
-    __name__ = "\chi"
+    __name__ = r"\chi"
 
-    def __init__(self, sympy_expression, position=None, domain=None, name="\chi"):
+    def __init__(self, sympy_expression, position=None, domain=None, name=r"\chi"):
         self.__name__ = name
         self.dimension = len(sympy_expression.free_symbols)
 
@@ -440,7 +440,7 @@ class basisfunction:
         self.decay = 1.0
 
     def normalize(self, domain=None):
-        """
+        r"""
         Set normalization factor $N$ of self ($\chi$) so that $\langle \chi \\vert \chi \\rangle = 1$.
         """
         s_12 = inner_product(self, self)
@@ -483,7 +483,7 @@ class basisfunction:
             return domain
 
     def __call__(self, *r):
-        """
+        r"""
         Evaluate function in coordinates ```*r``` (arbitrary dimensions).
 
         ## Returns
@@ -494,7 +494,7 @@ class basisfunction:
         return self.normalization * self.ket_numeric_expression(*r)
 
     def __mul__(self, other):
-        """
+        r"""
         Returns a basisfunction $\chi_{a*b}(\mathbf{r})$, where
         $\chi_{a*b}(\mathbf{r}) = \chi_a(\mathbf{r}) \chi_b(\mathbf{r})$
         """
@@ -514,7 +514,7 @@ class basisfunction:
         )
 
     def __add__(self, other):
-        """
+        r"""
         Returns a basisfunction  $\chi_{a+b}(\mathbf{r})$, where
         $\chi_{a+b}(\mathbf{r}) = \chi_a(\mathbf{r}) + \chi_b(\mathbf{r})$
         """
@@ -525,7 +525,7 @@ class basisfunction:
         )
 
     def __sub__(self, other):
-        """
+        r"""
         Returns a basisfunction  $\chi_{a-b}(\mathbf{r})$, where
         $\chi_{a-b}(\mathbf{r}) = \chi_a(\mathbf{r}) - \chi_b(\mathbf{r})$
         """
@@ -617,7 +617,7 @@ class operator_expression(object):
         return operator_expression(new_ops, new_coeffs)
 
     def apply(self, other_ket):
-        """
+        r"""
         # Apply operator to ket
 
         $\hat{\Omega} \vert a \rangle =  \vert a' \rangle $
@@ -965,7 +965,7 @@ def get_standard_basis(n):
 
 
 class ket(object):
-    """
+    r"""
     A class for vectors defined on general vector spaces
     Author: Audun Skau Hansen (a.s.hansen@kjemi.uio.no)
 

--- a/setup.py
+++ b/setup.py
@@ -5,19 +5,27 @@ with open("README.md", "r") as fh:
 
 
 setuptools.setup(
-     name='BraketLab',  
-     version='1.8.0',
-     author="Audun Skau Hansen",
-     author_email="audunsh4@gmail.com",
-     description="Educational tool for learning quantum theory with Jupyter Notebooks",
-     long_description=long_description,
-   long_description_content_type="text/markdown",
-     url="https://github.uio.no/audunsh/braketlab",
-     packages=setuptools.find_packages(),
-     classifiers=[
-         "Programming Language :: Python :: 3",
-         "License :: OSI Approved :: MIT License",
-         "Operating System :: OS Independent",
-     ],
-     install_requires = ["sympy", "numba", "evince", "bubblebox"],
- )
+    name='BraketLab',
+    version='1.8.0',
+    author="Audun Skau Hansen",
+    author_email="audunsh4@gmail.com",
+    description="Educational tool for learning quantum theory with Jupyter Notebooks",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.uio.no/audunsh/braketlab",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires = [
+        "sympy",
+        "numba",
+        "numpy",
+        "matplotlib",
+        "scipy",
+        "evince",
+        "bubblebox"
+    ],
+)


### PR DESCRIPTION
Edit setup.py to include packages on which braketlab explicitly depends instead of relying on them being installed indirectly through the dependency on evince and/or bubblebox.

Prepend strings containing math expressions (e.g. "$\chi$") with r to make them 'raw strings'. This avoids Python trying to interpret sequences like the "\c" as a special character like newline, tab, etc. and raising a SyntaxWarning.