### PR TITLE
Refactor unit tests, make them pass, and add testing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,62 @@ BraketLab is being developed by Audun Skau Hansen (a.s.hansen@kjemi.uio.no) at t
 
 # Installation
 
-Install the BraketLab-module using <code>pip install braketlab</code> from your terminal.
+With PyPI
+----
+
+The BraketLab package is available in the Python Package Index (PyPI), and can
+be installed from the command line using
+```sh
+pip install braketlab
+```
+
+
+From a local repository clone
+----
+
+The package can also be installed from a local clone of the repository. From
+within this directory, simply run
+```sh
+pip install .
+```
+Optionally one can install with the `-e` (`--editable`) flag to let changes in
+the source code take effect without having to perform a fresh install. The
+command for this would be
+```sh
+pip install -e .
+```
+
+
+Development
+====
+
+Installation
+----
+
+Install the dependencies from the `requirements.txt` file with the command
+```sh
+pip install -r requirements.txt
+```
+This includes more packages than are included in the normal pip install of
+BraketLab, like pytest for running the unit tests.
+
+It is not necessary to install BraketLab to work on it, but doing so may
+simplify the process by making it easier to deal with the import structure of
+various modules. Install it from a local clone of the repository with the
+command
+```sh
+pip install -e .
+```
+as explained in the Installation section.
+
+
+Testing
+----
+
+We encourage, and try to stick to, the habit of writing unit tests for the code
+wherever possible. These tests are stored in the `test` directory. To run all
+tests using pytest, run the command
+```sh
+pytest
+```
+from within this directory.

--- a/braketlab/real_solid_harmonics.py
+++ b/braketlab/real_solid_harmonics.py
@@ -3,6 +3,8 @@ Real solid harmonic Gaussian basis function,
 as presented in chapter 6 of the "Pink Bible" (*) Helgaker, T., Jorgensen, P., & Olsen, J. (2014). Molecular electronic-structure theory. John Wiley & Sons.
 Author: Audun Skau Hansen
 """
+import math
+
 import sympy as sp
 import numpy as np
 
@@ -29,8 +31,8 @@ def compute_binomial_coefficient(a: int, b: int) -> int:
     Compute the binomial coefficient ( a , b )
     [<a href="https://en.wikipedia.org/wiki/binomial_coefficient">Wikipedia</a>]
     """
-    return np.math.factorial(int(a)) // (
-        np.math.factorial(int(b)) * np.math.factorial(int(a - b))
+    return math.factorial(int(a)) // (
+        math.factorial(int(b)) * math.factorial(int(a - b))
     )
 
 
@@ -64,11 +66,11 @@ def N_factor(l: int, m: int) -> float:
     """
     return (
         1
-        / (2 ** abs(m) * np.math.factorial(l))
+        / (2 ** abs(m) * math.factorial(l))
         * np.sqrt(
             2
-            * np.math.factorial(l + abs(m))
-            * np.math.factorial(l - abs(m))
+            * math.factorial(l + abs(m))
+            * math.factorial(l - abs(m))
             * (2 ** (m == 0)) ** -1
         )
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 sympy
 evince
+bubblebox
 numba
 numpy
 matplotlib
 scipy
+pytest

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+# Empty file for import structure

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,32 +1,58 @@
-import braketlab as bk
 import numpy as np
+
+import braketlab as bk
+
+
+tol_exact = 1e-12
+tol_mc = 1e-2
+
 
 def test_1d_harmonic_oscillator_normality():
     psi_1 = bk.basisbank.get_harmonic_oscillator_function(1)
-    inner = np.abs(psi_1.bra@psi_1 - 1.0)
-    assert inner<=1e-5, f"Harmonic oscillator self-overlap is {inner}, but should be close to 1."
+    inner = psi_1.bra @ psi_1
+    expected = 1.0
+    error = abs(inner - expected)
+    assert error <= tol_exact, f"Harmonic oscillator self-overlap is {inner}," \
+        f" should be {expected}."
+
 
 def test_1d_harmonic_oscillator_orthogonality():
     psi_1 = bk.basisbank.get_harmonic_oscillator_function(1)
     psi_2 = bk.basisbank.get_harmonic_oscillator_function(2)
-    inner = np.abs(psi_1.bra@psi_2)
-    assert inner<=1e-5, f"Harmonic oscillator overlap is {inner}, but should be below 1e-5."
-    
+    inner = psi_1.bra @ psi_2
+    expected = 0.0
+    error = abs(inner - expected)
+    assert error <= tol_exact, f"Harmonic oscillator self-overlap is {inner}," \
+        f" should be {expected}."
+
 
 def test_3d_gto_normality():
+    # TODO: set random seed for monte carlo integration such that the tests are
+    # consistent, not sometimes passing and sometimes not
     psi_1 = bk.basisbank.get_gto(1.0, 1, 0)
-    inner = np.abs(psi_1.bra@psi_1 - 1.0)
-    assert inner<=1e-2, f"GTO self-overlap is {inner}, but should be close to 1."
+    inner = psi_1.bra @ psi_1
+    expected = 1.0
+    error = abs(inner - expected)
+    assert error <= tol_mc, f"GTO self-overlap is {inner}, should be {expected}."
+
 
 def test_3d_gto_orthogonality():
+    # TODO: set random seed for monte carlo integration such that the tests are
+    # consistent, not sometimes passing and sometimes not
     psi_1 = bk.basisbank.get_gto(1.0, 1, 0)
     psi_2 = bk.basisbank.get_gto(1.0, 2, 0)
-    inner = psi_1.bra@psi_2
-    assert np.abs(inner)<=1e-2, f"GTO same center overlap is {inner}, but should be below 1e-5."
-    
+    inner = psi_1.bra @ psi_2
+    expected = 0.0
+    error = abs(inner - expected)
+    assert error <= tol_mc, f"GTO same center overlap is {inner}, should be {expected}."
+
+
 def test_3d_gto_off_center_orthogonality():
+    # TODO: set random seed for monte carlo integration such that the tests are
+    # consistent, not sometimes passing and sometimes not
     psi_1 = bk.basisbank.get_gto(1.0, 1, 0)
-    psi_2 = bk.basisbank.get_gto(1.0, 2, 0, position = np.array([1.0, 0.6, 0.3]))
-    inner = psi_1.bra@psi_2
-    assert np.abs(inner + .217)<=1e-2, f"GTO off center overlap is {inner}, but should be close to -.217."
-    
+    psi_2 = bk.basisbank.get_gto(1.0, 2, 0, position=np.array([1.0, 0.6, 0.3]))
+    inner = psi_1.bra @ psi_2
+    expected = -0.217
+    error = abs(inner - expected)
+    assert error <= tol_mc, f"GTO off center overlap is {inner}, should be {expected}."


### PR DESCRIPTION
Refactor unit tests in test/test_integration.py for clarity, and fix some of the assertion messages which were not in line with the numerical values in the code.

Make the tests pass by replacing the calls to np.math.factorial with math.factorial in braketlab/real_solid_harmonics.py. Numpy.math was an alias for the standard library math module and deprecated in Numpy 1.25.

Expand the installation instructions in README, and add some information on the development, particularly running the tests with pytest.